### PR TITLE
only allow override of speakers if not tvOS

### DIFF
--- a/RNSound/RNSound.m
+++ b/RNSound/RNSound.m
@@ -307,11 +307,16 @@ RCT_EXPORT_METHOD(getCurrentTime:(nonnull NSNumber*)key
 
 RCT_EXPORT_METHOD(setSpeakerPhone:(BOOL) on) {
     AVAudioSession *session = [AVAudioSession sharedInstance];
-    if (on) {
-        [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
-    } else {
-        [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
-    }
+    #if TARGET_OS_TV
+      [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
+    #else
+      if (on) {
+          [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+      } else {
+          [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
+      }
+    #endif
+
     [session setActive:true error:nil];
 }
 


### PR DESCRIPTION
`AVAudioSessionPortOverrideSpeaker` is not allowed if tvOS
add `if/else` statement to limit this selection to non tvOS environments only